### PR TITLE
Rename envrionment and handle 'main' folder in terraform

### DIFF
--- a/workflow-templates/terraform-apply-registry.yml
+++ b/workflow-templates/terraform-apply-registry.yml
@@ -18,7 +18,7 @@ jobs:
   apply:
     runs-on: ubuntu-latest
     needs: [check_pr, check_apply]
-    environment: protected
+    environment: terraform
     steps:
       - name: Extract PR number
         id: pr

--- a/workflow-templates/terraform-apply.yml
+++ b/workflow-templates/terraform-apply.yml
@@ -28,7 +28,7 @@ jobs:
           - nonpci-prod
           - pci-stag
           - pci-prod
-    environment: protected
+    environment: terraform
     steps:
       - name: Extract PR number
         id: pr
@@ -142,6 +142,12 @@ jobs:
         if: steps.is_run.outputs.is_run
         run: |
           cd terraform
+
+          if [[ -d main ]]; then
+            mv plan.tfplan main/plan.tfplan
+            cd main
+          fi
+
           terraform init -input=false
           terraform workspace select quickpay-${{ matrix.name }}
           printf "# ${{ steps.credentials.outputs.name }}" > /tmp/apply.txt


### PR DESCRIPTION
# Changes
* When running `terraform-apply` or `terraform-apply-registry` workflow, use `envrionment` named `terraform` instead of `protected`
* Support for filestructure where terraform contains a `main` and `registry` folder

Relates to issue: https://github.com/QuickPay/ppro-backend/issues/140