### PR TITLE
Upgrade pastie upload action and utilize filepath to avoid "argument too long" error

### DIFF
--- a/workflow-templates/terraform-apply-registry.yml
+++ b/workflow-templates/terraform-apply-registry.yml
@@ -100,18 +100,12 @@ jobs:
           terraform workspace select quickpay-${{ steps.credentials.outputs.name }}
           terraform apply -input=false plan.tfplan -no-color 2>&1 | tee -a /tmp/apply.txt
 
-      - name: Retrieve apply
-        run: |
-          echo "APPLY<<__EOF__" >> $GITHUB_ENV
-          cat /tmp/apply.txt >> $GITHUB_ENV
-          echo "__EOF__" >> $GITHUB_ENV
-
       - name: Upload Apply to Pastie
         id: pastie
-        uses: QuickPay/pastie-upload-action@v1.0.1
+        uses: QuickPay/pastie-upload-action@v1.1.0
         with:
           credentials: ${{ secrets.PASTIE_CREDENTIALS }}
-          document_env: "APPLY"
+          document_path: "/tmp/apply.txt"
 
       - name: "Comment PR"
         uses: actions/github-script@v3

--- a/workflow-templates/terraform-apply.yml
+++ b/workflow-templates/terraform-apply.yml
@@ -157,19 +157,12 @@ jobs:
           terraform workspace select quickpay-${{ matrix.name }}
           terraform apply -input=false plan.tfplan -no-color 2>&1 | tee -a /tmp/apply.txt
 
-      - name: Retrieve apply
-        if: steps.is_run.outputs.is_run
-        run: |
-          echo "APPLY<<__EOF__" >> $GITHUB_ENV
-          cat /tmp/apply.txt >> $GITHUB_ENV
-          echo "__EOF__" >> $GITHUB_ENV
-
       - name: Upload Apply to Pastie
         id: pastie
-        uses: QuickPay/pastie-upload-action@v1.0.1
+        uses: QuickPay/pastie-upload-action@v1.1.0
         with:
           credentials: ${{ secrets.PASTIE_CREDENTIALS }}
-          document_env: "APPLY"
+          document_path: "/tmp/apply.txt"
 
       - name: "Comment PR"
         if: steps.is_run.outputs.is_run

--- a/workflow-templates/terraform-plan.yml
+++ b/workflow-templates/terraform-plan.yml
@@ -272,18 +272,12 @@ jobs:
           git commit -m "upload $COMMIT_SHA.tfplan"
           git push origin $BRANCH
 
-      - name: Retrieve plan
-        run: |
-          echo "PLAN<<__EOF__" >> $GITHUB_ENV
-          cat /tmp/plan.txt >> $GITHUB_ENV
-          echo "__EOF__" >> $GITHUB_ENV
-
       - name: Upload Plan to Pastie
         id: pastie
-        uses: QuickPay/pastie-upload-action@v1.0.1
+        uses: QuickPay/pastie-upload-action@v1.1.0
         with:
           credentials: ${{ secrets.PASTIE_CREDENTIALS }}
-          document_env: "PLAN"
+          document_path: "/tmp/plan.txt"
 
       - name: "Comment PR"
         uses: actions/github-script@v3


### PR DESCRIPTION
# Changes
Update pastie-upload-action from `v1.0.1` -> `v1.1.0`. Utilize new path parameter to avoid error "Argument too long".
