### PR TITLE
update slack notifications to be less cluttered

### DIFF
--- a/workflow-templates/ecs-deploy-api-and-consumer.yml
+++ b/workflow-templates/ecs-deploy-api-and-consumer.yml
@@ -151,9 +151,9 @@ jobs:
       - uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON_EMOJI: "aws"
-          SLACK_USERNAME: Deploy Notification
-          SLACK_TITLE: Message
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TECH_QP_DEPLOYS }}
           SLACK_MESSAGE: "*${{ github.event.inputs.environment }}:* ${{ github.actor }} deployed ${{ needs.find_constants.outputs.application_name }} ${{ github.event.inputs.image_tag }}"
           MSG_MINIMAL: true
+          SLACK_FOOTER: ""
+          SLACK_MSG_AUTHOR: " "
+          SLACK_TITLE: " "

--- a/workflow-templates/ecs-deploy-api-and-consumer.yml
+++ b/workflow-templates/ecs-deploy-api-and-consumer.yml
@@ -54,6 +54,13 @@ jobs:
           echo "ecs_cluster_name=$ECS_CLUSTER_NAME" >> $GITHUB_OUTPUT
           echo "ecr_repository_name=$ECR_REPOSITORY_NAME" >> $GITHUB_OUTPUT
           echo "ecr_repository_url=$ECR_REPOSITORY_URL" >> $GITHUB_OUTPUT
+
+          declare -A slack_webhook_deploy=(
+            ["stag"]="${{ secrets.SLACK_WEBHOOK_TECH_QP_DEPLOYS_STAGING }}"
+            ["prod"]="${{ secrets.SLACK_WEBHOOK_TECH_QP_DEPLOYS }}"
+          )
+          echo "slack_webhook_deploy=${slack_webhook_deploy[$ENVIRONMENT_PREFIX]}" >> $GITHUB_OUTPUT
+
   check_valid_input:
     name: "Check Valid Input for Deploy ${{ github.event.inputs.environment }}"
     runs-on: ubuntu-latest
@@ -151,8 +158,8 @@ jobs:
       - uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TECH_QP_DEPLOYS }}
-          SLACK_MESSAGE: "*${{ github.event.inputs.environment }}:* ${{ github.actor }} deployed ${{ needs.find_constants.outputs.application_name }} ${{ github.event.inputs.image_tag }}"
+          SLACK_WEBHOOK: ${{ steps.constants.outputs.slack_webhook_deploy }}
+          SLACK_MESSAGE: "*${{ github.event.inputs.environment }}:* ${{ github.actor }} deployed *${{ needs.find_constants.outputs.application_name }}:${{ github.event.inputs.image_tag }}*"
           MSG_MINIMAL: true
           SLACK_FOOTER: ""
           SLACK_MSG_AUTHOR: " "

--- a/workflow-templates/ecs-deploy.yml
+++ b/workflow-templates/ecs-deploy.yml
@@ -57,6 +57,13 @@ jobs:
           echo "ecs_cluster_name=$ECS_CLUSTER_NAME" >> $GITHUB_OUTPUT
           echo "ecr_repository_name=$ECR_REPOSITORY_NAME" >> $GITHUB_OUTPUT
           echo "ecr_repository_url=$ECR_REPOSITORY_URL" >> $GITHUB_OUTPUT
+
+          declare -A slack_webhook_deploy=(
+            ["stag"]="${{ secrets.SLACK_WEBHOOK_TECH_QP_DEPLOYS_STAGING }}"
+            ["prod"]="${{ secrets.SLACK_WEBHOOK_TECH_QP_DEPLOYS }}"
+          )
+          echo "slack_webhook_deploy=${slack_webhook_deploy[$ENVIRONMENT_PREFIX]}" >> $GITHUB_OUTPUT
+
   check_valid_input:
     name: "Check Valid Input for Deploy ${{ github.event.inputs.environment }}"
     runs-on: ubuntu-latest
@@ -128,8 +135,8 @@ jobs:
       - uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: "*${{ github.event.inputs.environment }}:* ${{ github.actor }} deployed ${{ needs.find_constants.outputs.application_name }} ${{ github.event.inputs.image_tag }}"
+          SLACK_WEBHOOK: ${{ steps.constants.outputs.slack_webhook_deploy }}
+          SLACK_MESSAGE: "*${{ github.event.inputs.environment }}:* ${{ github.actor }} deployed *${{ needs.find_constants.outputs.application_name }}:${{ github.event.inputs.image_tag }}*"
           MSG_MINIMAL: true
           SLACK_FOOTER: ""
           SLACK_MSG_AUTHOR: " "

--- a/workflow-templates/ecs-deploy.yml
+++ b/workflow-templates/ecs-deploy.yml
@@ -128,9 +128,9 @@ jobs:
       - uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON_EMOJI: "aws"
-          SLACK_USERNAME: Deploy Notification
-          SLACK_TITLE: Message
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: "*${{ github.event.inputs.environment }}:* ${{ github.actor }} deployed ${{ needs.find_constants.outputs.application_name }} ${{ github.event.inputs.image_tag }}"
           MSG_MINIMAL: true
+          SLACK_FOOTER: ""
+          SLACK_MSG_AUTHOR: " "
+          SLACK_TITLE: " "

--- a/workflow-templates/terraform-apply-registry.yml
+++ b/workflow-templates/terraform-apply-registry.yml
@@ -130,12 +130,12 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MSG_AUTHOR: " "
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TECH_QP_DEPLOYS }}
-          SLACK_TITLE: " "
           SLACK_MESSAGE: "*registry:* ${{ github.actor }} applied terraform for *${{ github.event.repository.name }}:${{ steps.find_plan.outputs.pr_branch }}*. See result at: ${{ steps.pastie.outputs.url }}"
           MSG_MINIMAL: true
           SLACK_FOOTER: ""
+          SLACK_MSG_AUTHOR: " "
+          SLACK_TITLE: " "
 
 
 

--- a/workflow-templates/terraform-apply-root.yml
+++ b/workflow-templates/terraform-apply-root.yml
@@ -141,12 +141,12 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MSG_AUTHOR: " "
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TECH_QP_DEPLOYS }}
-          SLACK_TITLE: " "
           SLACK_MESSAGE: "*root:* ${{ github.actor }} applied terraform for *${{ github.event.repository.name }}:${{ steps.find_plan.outputs.pr_branch }}*. See result at: ${{ steps.pastie.outputs.url }}"
           MSG_MINIMAL: true
           SLACK_FOOTER: ""
+          SLACK_MSG_AUTHOR: " "
+          SLACK_TITLE: " "
 
 
 

--- a/workflow-templates/terraform-apply.yml
+++ b/workflow-templates/terraform-apply.yml
@@ -196,12 +196,12 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MSG_AUTHOR: " "
           SLACK_WEBHOOK: ${{ steps.credentials.outputs.slack_webhook_deploy }}
-          SLACK_TITLE: " "
           SLACK_MESSAGE: "*${{ matrix.name }}:* ${{ github.actor }} applied terraform for *${{ github.event.repository.name }}:${{ steps.find_plan.outputs.pr_branch }}*. See result at: ${{ steps.pastie.outputs.url }}"
           MSG_MINIMAL: true
           SLACK_FOOTER: ""
+          SLACK_MSG_AUTHOR: " "
+          SLACK_TITLE: " "
 
 
 


### PR DESCRIPTION
# Changes
* Update Slack notifications to be less cluttered
* During deploy, send slack message to correct channel (`#tech-qp-deploys` or `#tech-qp-deploys-staging`, respectively)
* Streamlined format of message sent
